### PR TITLE
Extracted separate controllers and routers by tracks, artists, and albums

### DIFF
--- a/client/src/features/topTenTracksByYearSlice.js
+++ b/client/src/features/topTenTracksByYearSlice.js
@@ -14,7 +14,7 @@ const fetchTopTenTracksByYear = createAsyncThunk(
   'tracks/fetchTopTenByYear',
   async (year) => {
     try {
-      const response = await fetch(`/db/top10TracksByYear/?year=${year}`);
+      const response = await fetch(`/tracks/top10TracksByYear/?year=${year}`);
       const data = await response.json()
       console.log('fetchTopTenTracksByYear data in slice', data);
       return data;

--- a/client/src/features/topTenTracksSlice.js
+++ b/client/src/features/topTenTracksSlice.js
@@ -16,7 +16,7 @@ const fetchTopTenTracks = createAsyncThunk(
   'tracks/fetchTopTen',
     async () => {
       try {
-        const response = await fetch('/db/top10Tracks');
+        const response = await fetch('/tracks/top10Tracks');
         if (!response.ok) {
           console.log('Response not okay:', await response.text());
           throw new Error('Fetch request failed in fetchTopTenTracks in topTenTracksSlice.');

--- a/server/controllers/albumsController.js
+++ b/server/controllers/albumsController.js
@@ -1,0 +1,16 @@
+import { queries } from '../models/model.js';
+
+const albumsController = {};
+
+albumsController.getTop10Albums = async (req, res, next) => {
+  try {
+    const top10Albums = await queries.getTop10Albums();
+    res.locals.top10Albums = top10Albums;
+    return next();
+
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+export default albumsController;

--- a/server/controllers/artistsController.js
+++ b/server/controllers/artistsController.js
@@ -1,0 +1,17 @@
+import { queries } from '../models/model.js';
+
+const artistsController = {};
+
+artistsController.getTop10Artists = async (req, res, next) => {
+  try {
+    const top10Artists = await queries.getTop10Artists();
+    res.locals.top10Artists = top10Artists;
+    return next();
+
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+
+export default artistsController;

--- a/server/controllers/controller.js
+++ b/server/controllers/controller.js
@@ -13,45 +13,45 @@ const handleRequest = async (modelFunction, req, res) => {
   }
 };
 
-controller.getTop10Artists = (req, res) => handleRequest(queries.getTop10Artists, req, res);
-controller.getTop10Albums = (req, res) => handleRequest(queries.getTop10Albums, req, res);
-controller.getTop10Tracks = (req, res) => handleRequest(queries.getTop10Tracks, req, res);
+// controller.getTop10Artists = (req, res) => handleRequest(queries.getTop10Artists, req, res);
+// controller.getTop10Albums = (req, res) => handleRequest(queries.getTop10Albums, req, res);
+// controller.getTop10Tracks = (req, res) => handleRequest(queries.getTop10Tracks, req, res);
 
 
-//Ross added this to set up a route for front end slider to get tracks by year. right now the query times out each time. not using handleRequest
-//yet, as we are not responding to request yet, we are taking data to pass it on to them filter in another controller. didn't want to refactor the
-//whole codebase, so I created a custom controller just to get this working first.
-controller.getTop10TracksByYear = async (req, res, next) => {
-  try {
-    const data = await queries.getTop10TracksByYear();
-    console.log('data in getTop10TracksByYear:', data)
-    res.locals.tracks = data;
-    return next();
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-}
+// //Ross added this to set up a route for front end slider to get tracks by year. right now the query times out each time. not using handleRequest
+// //yet, as we are not responding to request yet, we are taking data to pass it on to them filter in another controller. didn't want to refactor the
+// //whole codebase, so I created a custom controller just to get this working first.
+// controller.getTop10TracksByYear = async (req, res, next) => {
+//   try {
+//     const data = await queries.getTop10TracksByYear();
+//     console.log('data in getTop10TracksByYear:', data)
+//     res.locals.tracks = data;
+//     return next();
+//   } catch (error) {
+//     res.status(500).json({ error: error.message });
+//   }
+// }
 
-controller.groupByTrack = (req, res, next) => {
-  const { tracks } = res.locals;
-  const tracker = {};
-  const groupedData = tracks.reduce((acc, { track_name, album_name, artist_name, ms_played, sesh_year }) => {
-    const key = JSON.stringify(artist_name + album_name + track_name);
-    const indexInAcc = tracker[key];
-    //check if acc has the artist album and track combo
-    //if no, add the artist album and track combo and set ms_played and return acc
-    if (!tracker[key] && tracker[key] !== 0) {
-      const index = acc.push({track_name, album_name, artist_name, ms_played}) - 1;
-      tracker[key] = index;
-      return acc;
-    }
-    //if yes, then add ms_played to existing ms_played and return acc
-    acc[indexInAcc].ms_played += ms_played;
-    return acc;
-  }, []);
-  res.locals.groupedByTrack = groupedData;
-  return next();
-}
+// controller.groupByTrack = (req, res, next) => {
+//   const { tracks } = res.locals;
+//   const tracker = {};
+//   const groupedData = tracks.reduce((acc, { track_name, album_name, artist_name, ms_played, sesh_year }) => {
+//     const key = JSON.stringify(artist_name + album_name + track_name);
+//     const indexInAcc = tracker[key];
+//     //check if acc has the artist album and track combo
+//     //if no, add the artist album and track combo and set ms_played and return acc
+//     if (!tracker[key] && tracker[key] !== 0) {
+//       const index = acc.push({track_name, album_name, artist_name, ms_played}) - 1;
+//       tracker[key] = index;
+//       return acc;
+//     }
+//     //if yes, then add ms_played to existing ms_played and return acc
+//     acc[indexInAcc].ms_played += ms_played;
+//     return acc;
+//   }, []);
+//   res.locals.groupedByTrack = groupedData;
+//   return next();
+// }
 
 //
 controller.getFields = (req, res) => handleRequest(queries.getFields, req, res);

--- a/server/controllers/controller.js
+++ b/server/controllers/controller.js
@@ -32,15 +32,6 @@ controller.getTop10TracksByYear = async (req, res, next) => {
   }
 }
 
-//Ross added this to set up a route for front end slider to get tracks by year. This controller will filter the results by year. Still need
-//to get a valid response to the front end, then we can build this controller out.
-// controller.filterByYear = (req, res) => {
-//   const { year } = req.query; //query string from front end request
-//   const { tracks } = res.locals;
-//   console.log('tracks length: ', tracks.length);
-//   return res.status(200).json(tracks);
-// }
-
 controller.groupByTrack = (req, res, next) => {
   const { tracks } = res.locals;
   const tracker = {};

--- a/server/controllers/tracksController.js
+++ b/server/controllers/tracksController.js
@@ -1,0 +1,56 @@
+import { queries } from '../models/model.js';
+
+const tracksController = {};
+
+tracksController.getTop10Tracks = async (req, res, next) => {
+  try {
+    const top10Tracks = await queries.getTop10Tracks();
+    res.locals.top10Tracks = top10Tracks;
+    return next();
+
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+//Ross added this to set up a route for front end slider to get tracks by year. right now the query times out each time. not using handleRequest
+//yet, as we are not responding to request yet, we are taking data to pass it on to them filter in another controller. didn't want to refactor the
+//whole codebase, so I created a custom controller just to get this working first.
+tracksController.getTop10TracksForYear = async (req, res, next) => {
+  const { year } = req.query;
+  console.log('year:', year)
+  try {
+    const tracksForYear = await queries.getTop10TracksForYear(year);
+    res.locals.tracksForYear = tracksForYear;
+    return next();
+
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+//input: track data for specific year
+//output: data grouped by track with total time played for each track in that year
+tracksController.getTracksByTimePlayed = (req, res, next) => {
+  const { tracksForYear } = res.locals;
+  const tracker = {};
+  //properties here should match the field names returned from model query
+  const tracksByTotalTimePlayed = tracksForYear.reduce((acc, { track_name, album_name, artist_name, ms_played, sesh_year }) => {
+    const key = JSON.stringify(artist_name + album_name + track_name);
+    const indexInAcc = tracker[key];
+    //check if acc has the artist album and track combo
+    //if no, add the artist album and track combo and set ms_played and return acc
+    if (!tracker[key] && tracker[key] !== 0) {
+      const index = acc.push({track_name, album_name, artist_name, ms_played}) - 1;
+      tracker[key] = index;
+      return acc;
+    }
+    //if yes, then add ms_played to existing ms_played and return acc
+    acc[indexInAcc].ms_played += ms_played;
+    return acc;
+  }, []);
+  res.locals.tracksByTotalTimePlayed = tracksByTotalTimePlayed;
+  return next();
+}
+
+export default tracksController;

--- a/server/models/model.js
+++ b/server/models/model.js
@@ -94,19 +94,20 @@ const queries = {
   //Ross added this to set up a route for front end slider to get tracks by year. commented out part of the query just to test as this query
   //keeps timing out. trying to join the sessions table on sessions.track_id = tracks.id and pull in the sessions.ts field to filter by year
   //downstream
-  getTop10TracksByYear: () => {
-    return executeQuery(async (supabase) => supabase
-    .from('sessions')
-    .select(`
-      track_name,
-      artist_name,
-      album_name,
-      ms_played,
-      sesh_year
-    `)
-    .eq('sesh_year', 2021)
-    .order('ms_played', { ascending: false })
-    ).then(tracks => tracks)
+  getTop10TracksForYear: (year) => 
+    executeQuery(async (supabase) => supabase
+      .from('sessions')
+      .select(`
+        track_name,
+        artist_name,
+        album_name,
+        ms_played,
+        sesh_year
+      `)
+      .eq('sesh_year', year)
+      .gte('ms_played', 60000)
+      .order('ms_played', { ascending: false })
+      ).then(tracks => tracks)
   //   .then(async tracks => {
   //   for (const track of tracks) {
   //     const trackInfo = await getTrackInfo(track.uri);
@@ -118,7 +119,6 @@ const queries = {
   //   }
   //   return tracks;
   // })
-  }
 
 };
 

--- a/server/routes/albumsRouter.js
+++ b/server/routes/albumsRouter.js
@@ -1,0 +1,8 @@
+import express from 'express';
+const router = express.Router();
+import controller from '../controllers/controller.js';
+
+router.get('/top10Albums', controller.getTop10Albums);
+
+// ES6 syntax
+export default router;

--- a/server/routes/albumsRouter.js
+++ b/server/routes/albumsRouter.js
@@ -1,8 +1,10 @@
 import express from 'express';
 const router = express.Router();
-import controller from '../controllers/controller.js';
+import albumsController from '../controllers/albumsController.js';
 
-router.get('/top10Albums', controller.getTop10Albums);
+router.get('/top10Albums', albumsController.getTop10Albums, (req, res) => {
+  return res.status(200).json(res.locals.top10Albums);
+});
 
 // ES6 syntax
 export default router;

--- a/server/routes/artistsRouter.js
+++ b/server/routes/artistsRouter.js
@@ -1,8 +1,10 @@
 import express from 'express';
 const router = express.Router();
-import controller from '../controllers/controller.js';
+import artistsController from '../controllers/artistsController.js';
 
-router.get('/top10Artists', controller.getTop10Artists);
+router.get('/top10Artists', artistsController.getTop10Artists, (req, res) => {
+  return res.status(200).json(res.locals.top10Artists);
+});
 
 // ES6 syntax
 export default router;

--- a/server/routes/artistsRouter.js
+++ b/server/routes/artistsRouter.js
@@ -1,0 +1,8 @@
+import express from 'express';
+const router = express.Router();
+import controller from '../controllers/controller.js';
+
+router.get('/top10Artists', controller.getTop10Artists);
+
+// ES6 syntax
+export default router;

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -2,12 +2,12 @@ import express from 'express';
 const router = express.Router();
 import controller from '../controllers/controller.js';
 
-router.get('/db/top10Albums', controller.getTop10Albums);
-router.get('/db/top10Artists', controller.getTop10Artists);
-router.get('/db/top10Tracks', controller.getTop10Tracks);
+// router.get('/db/top10Albums', controller.getTop10Albums);
+// router.get('/db/top10Artists', controller.getTop10Artists);
+// router.get('/db/top10Tracks', controller.getTop10Tracks);
 
-//Ross added this to set up a route for front end slider to get tracks by year. This is still timing out at the database call in models
-router.get('/db/top10TracksByYear', controller.getTop10TracksByYear, controller.groupByTrack, (req, res) => res.status(200).json(res.locals.groupedByTrack));
+// //Ross added this to set up a route for front end slider to get tracks by year. This is still timing out at the database call in models
+// router.get('/db/top10TracksByYear', controller.getTop10TracksByYear, controller.groupByTrack, (req, res) => res.status(200).json(res.locals.groupedByTrack));
 
 
 // get field names

--- a/server/routes/tracksRouter.js
+++ b/server/routes/tracksRouter.js
@@ -1,10 +1,14 @@
 import express from 'express';
 const router = express.Router();
-import controller from '../controllers/controller.js'; 
+import tracksController from '../controllers/tracksController.js'; 
 
-router.get('/top10Tracks', controller.getTop10Tracks);
+router.get('/top10Tracks', tracksController.getTop10Tracks, (req, res) => {
+  return res.status(200).json(res.locals.top10Tracks);
+});
 //Ross added this to set up a route for front end slider to get tracks by year. 
-router.get('/top10TracksByYear', controller.getTop10TracksByYear, controller.groupByTrack, (req, res) => res.status(200).json(res.locals.groupedByTrack));
+router.get('/top10TracksByYear', tracksController.getTop10TracksForYear, tracksController.getTracksByTimePlayed, (req, res) => {
+  return res.status(200).json(res.locals.tracksByTotalTimePlayed)
+});
 
 // ES6 syntax
 export default router;

--- a/server/routes/tracksRouter.js
+++ b/server/routes/tracksRouter.js
@@ -1,0 +1,10 @@
+import express from 'express';
+const router = express.Router();
+import controller from '../controllers/controller.js'; 
+
+router.get('/top10Tracks', controller.getTop10Tracks);
+//Ross added this to set up a route for front end slider to get tracks by year. 
+router.get('/top10TracksByYear', controller.getTop10TracksByYear, controller.groupByTrack, (req, res) => res.status(200).json(res.locals.groupedByTrack));
+
+// ES6 syntax
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,11 +1,15 @@
 // Importing express for the server and path for working with file pahts in Node.js.
 import express from 'express';
 import path from 'path';
+import dotenv from 'dotenv';
 // Importing cors middleware.
 import cors from 'cors';
 // Import router and routes.
 import router from './routes/router.js';
-import dotenv from 'dotenv';
+import tracksRouter from './routes/tracksRouter.js';
+import artistsRouter from './routes/artistsRouter.js';
+import albumsRouter from './routes/albumsRouter.js';
+
 
 // Load environment variables from .env.server.
 dotenv.config({ path: '.env.server' });
@@ -29,6 +33,9 @@ const corsOptions = {
 app.use(cors(corsOptions));
 
 // Mounting the router middleware to handle routes starting from the root.
+app.use('/tracks', tracksRouter);
+app.use('/artists', artistsRouter);
+app.use('/albums', albumsRouter);
 app.use('/', router);
 
 app.listen(PORT, () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = (env, argv) => {
             },
             // Proxying API requests to a backend server.
             proxy: {
-                '/db': {
+                '/': {
                     target: 'http://localhost:3000', // Replace with your backend server URL
                     changeOrigin: true,
                     secure: false,


### PR DESCRIPTION
**Back end changes:**

- Refactors in most files
- Added separate controllers for tracks, albums, and artists
- Added separate routers for tracks, albums, and artists
- Changed names for endpoints. Replaced 'db' with 'tracks', 'artists', or 'albums' depending on data being fetched
- Changed the shape of the controllers a bit. Not using handleRequest function anymore (you can feel free to refactor, but this is how I did it) b/c I am not responding to request from controller anymore, and I am assigning different names to the returned data and res.locals property based on returned data. 
- Responding to requests from routers.
- Since we are requesting from front end by year via query string, changed getTop10TracksForYear controller to pull the year from the query string and pass it to the model query.

**Front end changes:**

- Changed endpoints for fetches due to changing endpoints on backend