### PR TITLE
image updates. tracks pause. initialState updated for TopTracks. year state modified

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client';
-import Navbar from '../components/NavbarComp.jsx';
-import TopTracks from '../components/TopTracksComp.jsx';
-import TopAlbum from '../components/TopAlbumComp.jsx';
+import NavbarComp from '../components/NavbarComp.jsx';
+import TopTracksComp from '../components/TopTracksComp.jsx';
+import TopAlbumComp from '../components/TopAlbumComp.jsx';
 import GraphComp from '../components/GraphComp.jsx';
-import LogState from '../components/LogStateComp.jsx';
+import LogStateComp from '../components/LogStateComp.jsx';
 import YearSliderComp from '../components/SliderComp.jsx';
 // s
 // import DisplayYear from '../components/DisplayYear.jsx';
@@ -13,18 +13,16 @@ import '../../styles/index.scss';
 import { useSelector } from 'react-redux';
 
 export function App() {
-const { year } = useSelector(state => state.year);
+const { year } = useSelector(state => state.chosen);
 
   return (
     <>
-      <LogState/>
-      <Navbar/>
+      <LogStateComp/>
+      <NavbarComp/>
       <YearSliderComp/>
-      <div className="trackListAndAlbum">
-      <TopTracks/>
-      <TopAlbum/>
-      </div>
+      <TopTracksComp/>
       {year > 0 && <TopArtistsByYearComp/>}
+      {/* <TopAlbumComp/> */}
       <GraphComp/>
     </>
   )

--- a/client/src/components/GraphComp.jsx
+++ b/client/src/components/GraphComp.jsx
@@ -10,7 +10,7 @@ const GraphComp = () => {
   const [data, setData] = useState([]);
   const dispatch = useDispatch();
 
-  const { year, default : defaultYear, status: statusYear, error: errorYear } = useSelector(state => state.year);
+  const { year, default : defaultYear, status: statusYear, error: errorYear } = useSelector(state => state.chosen);
   const { arrData: topTracks, status: statusTopTracks, error: errorTopTracks } = useSelector(state => state.topTracks);
   const { arrData: topTracksByYear, status: statusTopTracksByYear, error: errorTopTracksByYear } = useSelector(state => state.topTracksByYear);
 

--- a/client/src/components/SliderComp.jsx
+++ b/client/src/components/SliderComp.jsx
@@ -8,7 +8,7 @@ import gsap from 'gsap';
 const YearSliderComp = () => {
 
   const dispatch = useDispatch();
-  const { year, status, error } = useSelector(state => state.year);
+  const { year, status, error } = useSelector(state => state.chosen);
 
   function handleSliderInput(e) {
     dispatch(setYear(e.target.value));

--- a/client/src/components/TopAristsByYearComp.jsx
+++ b/client/src/components/TopAristsByYearComp.jsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 const TopArtistsByYearComp = () => {
-  const { year } = useSelector(state => state.year);
+  const { year } = useSelector(state => state.chosen);
   const { arrData: topArtistsByYear, status: statusTopArtistsByYear, error: errorTopArtistsByYear } = useSelector(state => state.topArtistsByYear);
 
   return (

--- a/client/src/components/TopTracksComp.jsx
+++ b/client/src/components/TopTracksComp.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import logo from '../../assets/logo.png';
-import { fetchTopTracks } from '../features/slice.js';
+import { fetchTopTracks, setChosenTrack} from '../features/slice.js';
 // import store from '../store/store.js';
 import { useDispatch, useSelector } from 'react-redux';
 import playIcon from '../../assets/play_icon.png';
@@ -9,12 +9,21 @@ import pauseIcon from '../../assets/pause_icon.png';
 
 
 const TopTracksComp = () => {
-  const dispatch = useDispatch();
-  const [audio, setAudio] = useState(null);
-  const [isClickedId, setIsClickedId] = useState(null);
-  const [endClipTimeout, setEndClipTimeout] = useState(null);
 
-  const { year, default : defaultYear, status: statusYear, error: errorYear } = useSelector(state => state.year);
+  const {
+    year,
+    default: defaultYear,
+    status: statusYear,
+    error: errorYear
+  } = useSelector(state => state.chosen);
+
+  const {
+    name: chosenTrack,
+    image: chosenTrackImage,
+    artistName: chosenTrackArtistName,
+    albumName: chosenTrackAlbumName,
+  } = useSelector(state => state.chosen.track);
+
   const { arrData: topTracks, status: statusTopTracks, error: errorTopTracks } = useSelector(state => state.topTracks);
   const { arrData: topTracksByYear, status: statusTopTracksByYear, error: errorTopTracksByYear } = useSelector(state => state.topTracksByYear);
 
@@ -22,20 +31,10 @@ const TopTracksComp = () => {
   // then this gets served to the component that renders the tracks.
   const tracks = year === 0 ? topTracks : topTracksByYear;
 
-  // console.log('status in topTracksComp from reducer:', status)
-
-  // if (status === 'loading') {
-  //   // console.log('loading tracks from state in TopTracksComp.jsx');
-  // }
-
-  if (statusTopTracks === 'failed') {
-    console.log('FAILED: loading tracks from state in topTracksComp.jsx');
-  }
-
-  if (errorTopTracks) {
-    console.log('ERROR: loading tracks from state in TopTracksComp.jsx');
-  }
-
+  const dispatch = useDispatch();
+  const [audio, setAudio] = useState(null);
+  const [isClickedId, setIsClickedId] = useState(null);
+  const [endClipTimeout, setEndClipTimeout] = useState(null);
 
   useEffect(() => {
     // Dispatch the fetchTracks async thunk when the component mounts
@@ -45,12 +44,18 @@ const TopTracksComp = () => {
   }, [dispatch, statusTopTracks]);
 
 
-   const controlAudio = (previewUrl, trackId) => {
+
+
+
+  const controlImage = (trackName, artistName, albumName, imageUrl) => {
+    dispatch(setChosenTrack({name: trackName, image: imageUrl, artistName: artistName, albumName: albumName}))
+  }
+
+   const controlPlayback = (previewUrl, trackId, imageUrl, albumName, artistName) => {
 
     // For now, in the cases when the previewUrl is null as it sometimes is. 2024-01-12_05-10-PM PST.
     if (!previewUrl) return;
 
-    // function to fade the audio in or out
     const fadeAudio = (audio, increment, delay, callback) => {
       const fade = setInterval(() => {
         if((increment > 0 && audio.volume < 0.07) || (increment < 0 && audio.volume > 0.005)){
@@ -62,6 +67,20 @@ const TopTracksComp = () => {
         }
       }, delay);
     }
+
+    if (isClickedId === trackId && audio) {
+      fadeAudio(audio, -0.005, 250, () => {
+        audio.pause();
+        audio.currentTime = 0;
+        setIsClickedId(null);
+      });
+      return;
+    }
+
+    setIsClickedId(trackId);
+
+    // function to fade the audio in or out
+
 
     const playAudio = () => {
       setIsClickedId(trackId);
@@ -101,32 +120,58 @@ const TopTracksComp = () => {
       playAudio();
     }
   }
-
-  // Keith 2024-01-14_03-27-PM: changed the key 'preview' to 'audio_clip_url' for specificity.
+  function TrackElement({ track, controlPlayback, controlImage, isClickedId }) {
+    return (
+      <li>
+        <img src={playIcon} alt="" style={isClickedId === track.id ? {display: 'none'} : {display: 'block'}}/>
+        <img src={pauseIcon} alt="" style={isClickedId === track.id ? { display: 'block' } : { display: 'none' }} />
+        <div className="trackScrollWrapper">
+          <div className={isClickedId === track.id ? 'onPlay' : 'tracks'} >
+            <div onClick={() => {
+              controlPlayback(track.audio_clip_url, track.id, track.image_url, track.album_name, track.artist_name)
+              &
+              controlImage(track.name, track.artist_name, track.album_name, track.image_url)
+              if (isClickedId === track.id) {
+                setIsClickedId(null);
+              } else {
+                setIsClickedId(track.id);
+              }
+            }}>
+            {track.name} - {track.artist_name}
+            </div>
+            <div onClick={() => controlPlayback(track.audio_clip_url, track.id, track.image_url, track.album_name, track.artist_name)}>
+            {track.name} - {track.artist_name}
+            </div>
+          </div>
+        </div>
+      </li>
+    );
+  }
 
   return (
-    <div className="TopTracks">
+    <div className="TopTracksAndImageContainer">
+    <div className="TopTracksContainer">
       <h3>TOP 10 TRACKS</h3>
       <ul>
         {tracks.map(track => (
-          <li key={track.id}>
-            <img src={playIcon} alt="" style={isClickedId === track.id ? {display: 'none'} : {display: 'block'}}/>
-            <img src={pauseIcon} alt="" style={isClickedId === track.id ? { display: 'block' } : { display: 'none' }} />
-            <div className="scrollWrapper">
-              <div className={isClickedId === track.id ? 'onPlay' : 'tracks'} >
-                <div onClick={() => controlAudio(track.audio_clip_url, track.id)}>
-                {track.name} - {track.artist_name}
-                </div>
-                <div onClick={() => controlAudio(track.audio_clip_url, track.id)}>
-                {track.name} - {track.artist_name}
-                </div>
-              </div>
-            </div>
-          </li>
-          ))}
+          <TrackElement
+            key={track.id}
+            track={track}
+            controlPlayback={controlPlayback}
+            controlImage={controlImage}
+            isClickedId={isClickedId}
+          />
+        ))}
       </ul>
     </div>
-  )
-}
+    <div className="trackImage">
+      <div className="trackImageCard">
+        <img src={chosenTrackImage} alt="image" />
+        <h4>{chosenTrackArtistName} <br /> {chosenTrackAlbumName}</h4>
+      </div>
+    </div>
+  </div>
+)
+        }
 
 export default TopTracksComp;

--- a/client/src/features/slice.js
+++ b/client/src/features/slice.js
@@ -11,19 +11,255 @@ const initialState = {
   error: "",
 };
 
-const yearSlice = createSlice({
-  name: 'year',
+const chosenSlice = createSlice({
+  name: 'chosen',
   initialState: {
     year: 0,
-    default: 'all-time',
+    defaultYear: 'all-time',
+    track: {
+      name: "Innerbloom",
+      image: "https://i.scdn.co/image/ab67616d00001e0260e5059dcab339142d7642bb",
+      artistName: "Rüfüs Du Sol",
+      albumName: "Bloom",
+    },
+    topTracks: [
+      {
+          "id": 173951,
+          "name": "Innerbloom",
+          "artist_id": 991,
+          "artist_name": "RÜFÜS DU SOL",
+          "album_id": 9777,
+          "album_name": "Bloom",
+          "playtime_ms": 91554472,
+          "playtime_minutes": 1525,
+          "plays": 298,
+          "skips": 8,
+          "last_updated": null,
+          "uri": "6CGMZijOAZvTXG21T8t6R0",
+          "audio_clip_url": "https://p.scdn.co/mp3-preview/ef46ea22943e90da37c6a9d0d16efa872411fbcd?cid=5e8a637ef19a471f918c9682636ab427",
+          "explicit": false,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e0260e5059dcab339142d7642bb",
+          "popularity": 76,
+          "duration_ms": 578040,
+          "api_data_added": true,
+          "album_uri": "4EAehCii5lZgeewct1LA5p",
+          "artist_uri": "5Pb27ujIyYb33zBqVysBkj"
+      },
+      {
+          "id": 172702,
+          "name": "Cold Little Heart",
+          "artist_id": 4007,
+          "artist_name": "Michael Kiwanuka",
+          "album_id": 10273,
+          "album_name": "Love & Hate",
+          "playtime_ms": 72784310,
+          "playtime_minutes": 1213,
+          "plays": 219,
+          "skips": 9,
+          "last_updated": null,
+          "uri": "0qprlw0jfsW4H9cG0FFE0Z",
+          "audio_clip_url": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview125/v4/00/c1/ff/00c1ffdd-8e91-a838-e9cc-2b363c6bc763/mzaf_5700383525985384309.plus.aac.ep.m4a",
+          "explicit": false,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e021070095e88dce90a090171b5",
+          "popularity": 68,
+          "duration_ms": 597600,
+          "api_data_added": true,
+          "album_uri": "0qxsfpy2VU0i4eDR9RTaAU",
+          "artist_uri": "0bzfPKdbXL5ezYW2z3UGQj"
+      },
+      {
+          "id": 173361,
+          "name": "Open Eye Signal",
+          "artist_id": 1534,
+          "artist_name": "Jon Hopkins",
+          "album_id": 6376,
+          "album_name": "Immunity",
+          "playtime_ms": 68397135,
+          "playtime_minutes": 1139,
+          "plays": 344,
+          "skips": 43,
+          "last_updated": null,
+          "uri": "6wMTeVootJ8RdCLNOZy5Km",
+          "audio_clip_url": "https://p.scdn.co/mp3-preview/8be84dff9a174bc14c01c66fd7c63a9a7bc9e24c?cid=5e8a637ef19a471f918c9682636ab427",
+          "explicit": false,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e02235e762de339c6076aa824dd",
+          "popularity": 48,
+          "duration_ms": 468586,
+          "api_data_added": true,
+          "album_uri": "1rxWlYQcH945S3jpIMYR35",
+          "artist_uri": "7yxi31szvlbwvKq9dYOmFI"
+      },
+      {
+          "id": 174842,
+          "name": "Needed Me",
+          "artist_id": 4973,
+          "artist_name": "Rihanna",
+          "album_id": 2012,
+          "album_name": "ANTI (Deluxe)",
+          "playtime_ms": 68044314,
+          "playtime_minutes": 1134,
+          "plays": 479,
+          "skips": 9,
+          "last_updated": null,
+          "uri": "4pAl7FkDMNBsjykPXo91B3",
+          "audio_clip_url": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview116/v4/ee/04/71/ee047178-887c-8782-0da2-5ac534aa6a8b/mzaf_9939519010949651839.plus.aac.ep.m4a",
+          "explicit": true,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e0233c6b920eabcf4c00d7a1093",
+          "popularity": 85,
+          "duration_ms": 191600,
+          "api_data_added": true,
+          "album_uri": "4UlGauD7ROb3YbVOFMgW5u",
+          "artist_uri": "5pKCCKE2ajJHZ9KAiaK11H"
+      },
+      {
+          "id": 164022,
+          "name": "A New Error",
+          "artist_id": 3296,
+          "artist_name": "Moderat",
+          "album_id": 7298,
+          "album_name": "Moderat",
+          "playtime_ms": 65984815,
+          "playtime_minutes": 1099,
+          "plays": 375,
+          "skips": 53,
+          "last_updated": null,
+          "uri": "1fmoCZ6mtMiqA5GHWPcZz9",
+          "audio_clip_url": "https://p.scdn.co/mp3-preview/bd95b91e5199ea14d7f63aa3f0d855b565ecdc34?cid=5e8a637ef19a471f918c9682636ab427",
+          "explicit": false,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e0227ce0e73b9cf23e8e22ebfe4",
+          "popularity": 62,
+          "duration_ms": 367306,
+          "api_data_added": true,
+          "album_uri": "2HEh23ogCT3wiYfag2iMxD",
+          "artist_uri": "2exkZbmNqMKnT8LRWuxWgy"
+      },
+      {
+          "id": 169953,
+          "name": "Daydreamer - Gryffin Remix",
+          "artist_id": 4260,
+          "artist_name": "Bipolar Sunshine",
+          "album_id": 5393,
+          "album_name": "Beach Bar",
+          "playtime_ms": 61957010,
+          "playtime_minutes": 1032,
+          "plays": 366,
+          "skips": 6,
+          "last_updated": null,
+          "uri": "587iEBVD1EfCe7n45Y4SZP",
+          "audio_clip_url": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview125/v4/26/d0/f9/26d0f9fc-bd13-9c5c-90e4-54a9454ad0f1/mzaf_16469622375669652063.plus.aac.ep.m4a",
+          "explicit": false,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e02fdcc184078a2f7fc42f5840e",
+          "popularity": 33,
+          "duration_ms": 251027,
+          "api_data_added": true,
+          "album_uri": "6iZCUbQE7xJnFxjHyDpVqs",
+          "artist_uri": "0CjWKoS55T7DOt0HJuwF1H"
+      },
+      {
+          "id": 159894,
+          "name": "Two Bodies",
+          "artist_id": 2561,
+          "artist_name": "Flight Facilities",
+          "album_id": 2103,
+          "album_name": "Down To Earth",
+          "playtime_ms": 58950285,
+          "playtime_minutes": 982,
+          "plays": 353,
+          "skips": 7,
+          "last_updated": null,
+          "uri": "3WqifovLWUQICYOAad0aNP",
+          "audio_clip_url": "https://p.scdn.co/mp3-preview/951d432c8ddfca2b4fa6da1855d13f8ae212a864?cid=5e8a637ef19a471f918c9682636ab427",
+          "explicit": false,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e02e040d158ab507a5fc62638ea",
+          "popularity": 43,
+          "duration_ms": 368346,
+          "api_data_added": true,
+          "album_uri": "5V8798yQx7GwVCXQTyIOJz",
+          "artist_uri": "1lc8mnyGrCLtPhCoWjRxjM"
+      },
+      {
+          "id": 172880,
+          "name": "Ultralight Beam",
+          "artist_id": 4314,
+          "artist_name": "Kanye West",
+          "album_id": 6117,
+          "album_name": "The Life Of Pablo",
+          "playtime_ms": 57813893,
+          "playtime_minutes": 963,
+          "plays": 370,
+          "skips": 8,
+          "last_updated": null,
+          "uri": "1eQBEelI2NCy7AUTerX0KS",
+          "audio_clip_url": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview116/v4/1c/4f/84/1c4f84fa-5152-4930-61a4-6a4130b8640f/mzaf_72321694340480158.plus.aac.ep.m4a",
+          "explicit": true,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e022a7db835b912dc5014bd37f4",
+          "popularity": 73,
+          "duration_ms": 320680,
+          "api_data_added": true,
+          "album_uri": "7gsWAHLeT0w7es6FofOXk1",
+          "artist_uri": "5K4W6rqBFWDnAN6FQUkS6x"
+      },
+      {
+          "id": 162853,
+          "name": "Party Monster",
+          "artist_id": 1616,
+          "artist_name": "The Weeknd",
+          "album_id": 6621,
+          "album_name": "Starboy",
+          "playtime_ms": 54801508,
+          "playtime_minutes": 913,
+          "plays": 353,
+          "skips": 10,
+          "last_updated": null,
+          "uri": "4F7A0DXBrmUAkp32uenhZt",
+          "audio_clip_url": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview122/v4/f6/24/aa/f624aaa6-32b5-021f-6c7d-1ee9ceb99224/mzaf_2995226288921259077.plus.aac.ep.m4a",
+          "explicit": true,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e024718e2b124f79258be7bc452",
+          "popularity": 84,
+          "duration_ms": 249213,
+          "api_data_added": true,
+          "album_uri": "2ODvWsOgouMbaA5xf0RkJe",
+          "artist_uri": "1Xyo4u8uXC1ZmMpatF05PJ"
+      },
+      {
+          "id": 170580,
+          "name": "Until the Sun Needs to Rise",
+          "artist_id": 991,
+          "artist_name": "RÜFÜS DU SOL",
+          "album_id": 9777,
+          "album_name": "Bloom",
+          "playtime_ms": 53447245,
+          "playtime_minutes": 890,
+          "plays": 306,
+          "skips": 3,
+          "last_updated": null,
+          "uri": "31POmfMW3ebBiqriWIeNIc",
+          "audio_clip_url": "https://p.scdn.co/mp3-preview/8d8331ae54c02e8ca90555f275c0979b9ab577d7?cid=5e8a637ef19a471f918c9682636ab427",
+          "explicit": false,
+          "image_url": "https://i.scdn.co/image/ab67616d00001e022b4a6961af25f0ccb808d36f",
+          "popularity": 64,
+          "duration_ms": 292044,
+          "api_data_added": true,
+          "album_uri": "1SR9xhoYg57S95GDFpyQGT",
+          "artist_uri": "5Pb27ujIyYb33zBqVysBkj"
+      }
+  ],
     status: "idle",
     error: ""
   },
   reducers: {
     setYear: (state, action) => {
       state.year = action.payload;
-      console.log('yearSlice: state.year:', state.year);
+      // console.log('nowSlice: state.chosen:', state.year);
     },
+    setChosenTrack: (state, action) => {
+      state.track = action.payload;
+      // console.log('nowSlice: state.track:', state.track);
+    },
+    setTopTracks: (state, action) => {
+      state.topTracks = action.payload;
+      // console.log('nowSlice: state.topTracks:', state.topTracks);
+    }
   },
 });
 
@@ -41,6 +277,7 @@ const slice = (endpoint, title, filter) => {
         throw new Error(`Fetch request failed at endpoint ${url}`);
       }
       const responseJson = await response.json();
+
       return responseJson;
 
     }
@@ -57,8 +294,12 @@ const slice = (endpoint, title, filter) => {
         })
         .addCase(actions.fulfilled, (state, action) => {
           state.status = "succeeded";
-
-          state.arrData = action.payload;
+          // this catches the case where the data is an array or an object
+          if (Array.isArray(action.payload)) {
+            state.arrData = action.payload;
+          } else {
+            state.objData = action.payload;
+          }
           if (title.includes('ByYear')) {
             state.year = action.meta.arg.query;
             state.objData[state.year] = action.payload;
@@ -85,8 +326,8 @@ const { reducer: topArtistsByYearSlice, actions: fetchTopArtistsByYear } = slice
 const { reducer: topTracksByYearSlice, actions: fetchTopTracksByYear } = slice('/tracks','topTracksByYear', '?year=');
 
 
-const { reducer: yearReducer, actions: yearActions } = yearSlice;
-const { setYear } = yearActions;
+const { reducer: chosenReducer, actions: chosenActions } = chosenSlice;
+const { setYear, setChosenTrack, setTopTracks } = chosenActions;
 
 export {
   fetchTopTracks,
@@ -99,6 +340,9 @@ export {
   topArtistsSlice,
   topTracksByYearSlice,
   topArtistsByYearSlice,
+  topAlbumsByYearSlice,
   setYear,
-  yearReducer
+  setChosenTrack,
+  setTopTracks,
+  chosenReducer
 };

--- a/client/src/store/store.js
+++ b/client/src/store/store.js
@@ -1,5 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { topTracksSlice, topAlbumsSlice, topArtistsSlice, topTracksByYearSlice, topArtistsByYearSlice, yearReducer } from '../features/slice.js';
+import { topTracksSlice, topAlbumsSlice, topArtistsSlice, topTracksByYearSlice, topArtistsByYearSlice, topAlbumsByYearSlice, chosenReducer } from '../features/slice.js';
 
 const store = configureStore({
   reducer: {
@@ -8,7 +8,8 @@ const store = configureStore({
     topArtists: topArtistsSlice.reducer,
     topTracksByYear: topTracksByYearSlice.reducer,
     topArtistsByYear: topArtistsByYearSlice.reducer,
-    year: yearReducer
+    topAlbumsByYear: topAlbumsByYearSlice.reducer,
+    chosen: chosenReducer
   },
   // devTools: process.env.NODE_ENV !== 'production',
 });

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -221,7 +221,7 @@ ul {
     }
 }
 
-.TopTracks {
+.TopTracksContainer {
   color: $white;
   font-family: $font-family-mono;
   width: 422px;
@@ -240,7 +240,7 @@ ul {
   100% { left: -100%; }
 }
 
-.TopTracks li {
+.TopTracksContainer li {
   border: 0.3px solid rgba(255, 255, 255, 0.7);
   display: flex;
   width: 400px;
@@ -259,7 +259,7 @@ ul {
     }
 }
 
-.scrollWrapper {
+.trackScrollWrapper {
   width: 100%;
   position: relative;
   overflow: hidden;
@@ -288,13 +288,45 @@ ul {
   }
 }
 
-.trackListAndAlbum {
+.TopTracksAndImageContainer {
   display: flex;
   justify-content: space-around;
   align-items: flex-start;
   @media (max-width: 1055px) {
     flex-direction: column;
     align-items: center;
+  }
+}
+
+.trackImage {
+  h3 {
+    margin: 0;
+    text-align: end;
+    margin-bottom: 15px;
+    @media (max-width: 1055px) {
+      text-align: center;
+    }
+  }
+}
+
+.trackImageCard {
+  background: linear-gradient($lightBlue, $skyeBlue);
+  width: 500px;
+  height: 515px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+    img {
+        padding-top: 25px;
+        height: 400px;
+        width: 425px;
+        object-fit: cover;
+      }
+  h4 {
+    font-weight: 300;
+    text-align: end;
+    margin-right: -250px;
   }
 }
 


### PR DESCRIPTION
- image next to topTracks now displays album image from playing track. 
- initial track and topTracks (alltime) saved to initialstate
- - in what is now 'chosen', formerly 'year'. ( So, chosen.year, chosen.track, etc.).
- Playing track saved to state.
- Tracks fade out and pause when already playing and clicked again.

to-do:
- make images fade in/out at same rate as audio