### PR TITLE
fetching top 10 albums for year and appending image urls on server and displaying top album on front end

### DIFF
--- a/client/src/app/App.jsx
+++ b/client/src/app/App.jsx
@@ -25,7 +25,7 @@ export function App() {
       <YearSliderComp/>
       <TopTracksComp/>
       <TopArtistsComp/>
-      {/* <TopAlbumComp/> */}
+      <TopAlbumComp/>
       <GraphComp/>
     </>
   )

--- a/client/src/components/SliderComp.jsx
+++ b/client/src/components/SliderComp.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client';
 import '../../styles/index.scss';
 import { useDispatch, useSelector } from 'react-redux';
-import { setYear, fetchTopTracks, fetchTopArtists, setChosenTrack } from '../features/slice.js';
+import { setYear, fetchTopTracks, fetchTopArtists, setChosenTrack, fetchTopAlbums } from '../features/slice.js';
 import gsap from 'gsap';
 
 const SliderComp = () => {
@@ -20,18 +20,20 @@ const SliderComp = () => {
         dispatch(setChosenTrack(action.payload[0]))
       }
     })
-    dispatch(fetchTopArtists(year)).then((action) => {
-      if (fetchTopArtists.fulfilled.match(action)) {
+
+    dispatch(fetchTopAlbums(year));
+    //COMMENTED OUT BECAUSE it was interfering with the fadeout animation. we want to fetch top artists only after the fadeout is complete
+    // dispatch(fetchTopArtists(year)).then((action) => {
+    //   if (fetchTopArtists.fulfilled.match(action)) {
     gsap.to('.eachArtist', {
       opacity: 0,
-      duration: 0.2,
+      duration: 0.3,
       onComplete: () => {
         dispatch(fetchTopArtists(year));
       }
     });
-      }
-    })
-  // dispatch(fetchTopAlbums(year))
+    //   }
+    // })
   }
 
   // Dispatch the fetch async thunks when the component mounts

--- a/client/src/components/TopAlbumComp.jsx
+++ b/client/src/components/TopAlbumComp.jsx
@@ -1,24 +1,49 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import albumImagePlaceholder from '../../assets/album.png';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 const TopAlbumPage = () => {
-  const { year } = useSelector(state => state.year)
-  const {arrData: topAlbumsByYear, status: statusTopAlbumsByYear, error: errorTopAlbumsByYear} = useSelector(state = state.topAlbumsByYear)
-  console.log(topAlbumsByYear)
+  const { year } = useSelector(state => state.chosen)
+  const {arrData: topAlbumsByYear, status: statusTopAlbumsByYear, error: errorTopAlbumsByYear} = useSelector(state => state.topAlbums);
+  // console.log('topAlbums in TopAlbumPage: ', topAlbumsByYear);
+  const [album, setAlbum] = useState(null);
+  // console.log('album in TopAlbumPage:', album)
+
+  useEffect(() => {
+    function getFirstAlbumWithImage(topAlbumsByYear) {
+      for (let album of topAlbumsByYear) {
+        if (album.image_url) return album;
+      }
+      return null;
+    }
+  
+    setAlbum(getFirstAlbumWithImage(topAlbumsByYear));
+  }, [topAlbumsByYear, statusTopAlbumsByYear]);
+
 
   return (
-    <div className='topAlbumDisplay'>
+    <div className='topAlbumsDisplay'>
       <h3>And couldn't get enough of:</h3>
       <div className='albumContainer'>
-        <img src={topAlbumsByYear.arrData[0].image_url} alt="image" />
+      {album &&
         <>
-          <p>{topAlbumsByYear.arrData[0].album_name}</p>
-          <p>{topAlbumsByYear.arrData[0].artist_name}</p>
+          <img src={album.image_url} alt="image" />
+          <h4>{album.artist_name} <br /> {album.name}</h4>
         </>
+      } 
+      {!album &&
+        <>
+          <img src={albumImagePlaceholder} alt="image" />
+        </>
+      }
       </div>
     </div>
   )
 };
 
 export default TopAlbumPage;
+
+
+
+
+

--- a/client/src/components/TopArtistsComp.jsx
+++ b/client/src/components/TopArtistsComp.jsx
@@ -28,7 +28,8 @@ const TopArtistsComp = () => {
 
   return (
     <div className='artistsWrapper'>
-      <h3>Your favorite artists were</h3>
+      <h3>Let's take a trip down memory lane</h3>
+      <h3>You were jammin' to:</h3>
       <div className='artists'>
         {status === 'succeeded' && mappedArtists.map((element, index) => (
           <React.Fragment key={index}>

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -16,7 +16,7 @@ $lightBlue: #ADADFF;
 $skyeBlue: #6072D1;
 
 $font-family-mono: "Red Hat Mono", monospace;
-// $font-family-roboto-mono: "Roboto Mono", monospace;
+$font-family-roboto-mono: "Roboto Mono", monospace;
 $font-family-header: "Rubik", sans-serif;
 //gradient for headers / slider etc:
 $gradient-text: -webkit-linear-gradient(60deg, $purple, $blue, $green);
@@ -109,7 +109,7 @@ ul {
 }
 
 .graphWrapper {
-  margin: 50px 0px;
+  margin: 190px 0px;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -376,12 +376,13 @@ ul {
   justify-content: center;
   align-items: center;
   h3 {
-    font-family: $font-family-mono;
+    font-family: $font-family-header;
     font-weight: 800;
-    margin-top: 1em;
+    margin-top: 3em;
     margin-bottom: 1em;
-    font-size: 50px;
-    background: $gradient-text;
+    font-size: 60px;
+    background: $white;
+    // background: $gradient-text;
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -389,7 +390,7 @@ ul {
 }
 
 .artists {
-  width: 80%;
+  width: 60%;
   height: 40%;
   margin-bottom: 3em;
   display: flex;
@@ -401,9 +402,9 @@ ul {
 }
 
 .artists p {
-  // font-family: $font-family-roboto-mono;
-  font-family: $font-family-header;
-  font-size: 28px;
+  font-family: $font-family-roboto-mono;
+  // font-family: $font-family-header;
+  font-size: 30px;
   color: $white;
 }
 
@@ -412,35 +413,67 @@ ul {
   display: flex;
   flex-direction: column;
   height: 60vh;
-  justify-content: center;
+  // justify-content: center;
   align-items: center;
   h3 {
-    width: 1010px;
-    height: 76px;
-    top: 3036px;
-    left: 359px;
-    font-family: $font-family-mono;
-    font-size: 64px;
+    // width: 1010px;
+    // height: 76px;
+    // top: 3036px;
+    // left: 359px;
+    font-family: $font-family-header;
+    font-size: 60px;
     font-weight: 700;
     line-height: 76px;
-    letter-spacing: 0em;
-    background: $gradient-text;
+    // letter-spacing: 0em;
+    background: $white;
     text-align: center;
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
+    margin-top: 3em;
+
   }
 }
 
-.topAlbumContainer {
-    width: 980px;
-    height: 988px;
-    position: absolute;
-    top: 3164px;
-    left: 374px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+// .albumContainer img {
+    // width: 980px;
+    // height: 988px;
+    // position: absolute;
+    // top: 3164px;
+    // left: 374px;
+    // display: flex;
+    // flex-direction: column;
+    // justify-content: center;
+    // align-items: center;
+    // position: absolute;
+    // top: 3164px;
+    // left: 374px;
+    // display: flex;
+    // flex-direction: column;
+    // justify-content: center;
+    // align-items: center;
+    // width: 800px;
+    // height: 800px;
+// }
 
+.albumContainer {
+  background: linear-gradient($lightBlue, $skyeBlue);
+  width: 800px;
+  height: 824px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+    img {
+        padding-top: 25px;
+        height: 640px;
+        width: 660px;
+        object-fit: cover;
+      }
+  h4 {
+    font-weight: 300;
+    text-align: end;
+    margin-right: -250px;
+  }
 }
+

--- a/server/controllers/albumsController.js
+++ b/server/controllers/albumsController.js
@@ -17,13 +17,44 @@ albumsController.getTopAlbums = async (req, res, next) => {
 albumsController.getTopAlbumsByYear = async (req, res, next) => {
   const { year } = req.query;
   try {
-    const topAlbumsByYear = await queries.getTopAlbumsByYear(year);
-    res.locals.topAlbumsByYear = topAlbumsByYear;
+    //we don't have a 'top_albums_by_year' only view, so calling 'top_albums_by_year_month'. when we add a query for 'top_albums_by_year', change
+    //this query to use that
+    const topAlbumsByYear = await queries.getTopAlbumsByYearByMonth(year);
+    //we don't need 12 copies of the album data per year, so reduce
+    let reducedTopAlbumsByYear = topAlbumsByYear.reduce((acc, { year, rank, album_name, yearly_playtime_minutes, yearly_playtime_ms, yearly_playtime_hours, album_id }) => {
+      const json = JSON.stringify({ year, rank, album_name, yearly_playtime_minutes, yearly_playtime_ms, yearly_playtime_hours, album_id});
+      if (!acc.includes(json)) return [...acc, json];
+      return acc;
+    }, []);
+    reducedTopAlbumsByYear = reducedTopAlbumsByYear.map(album => JSON.parse(album));
+    res.locals.topAlbumsByYear = reducedTopAlbumsByYear;
     return next();
 
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
+}
+
+//add image_url as a property on each album object
+albumsController.getAlbumsCoverArt = async (req, res, next) => {
+  const { topAlbumsByYear } = res.locals;
+  const albumNameArray = topAlbumsByYear.map(({ album_name }) => album_name);
+  try {
+    let albumNameAndImages = await queries.getAlbumImageUrl(albumNameArray);
+    albumNameAndImages = albumNameAndImages.reduce((acc, curr) => {
+      if (!acc.includes(curr)) return [...acc, curr];
+      return acc;
+    }, []);
+    res.locals.topAlbumsByYear = topAlbumsByYear.map(albumObj => {
+      const albumImageUrl = albumNameAndImages.filter(albumNameAndImageObj => albumNameAndImageObj.album_name === albumObj.album_name);
+      return {...albumObj, image_url: albumImageUrl[0].image_url};
+    });
+    return next();
+
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+
 }
 
 albumsController.getTopAlbumsByYearByMonth = async (req, res, next) => {

--- a/server/models/model.js
+++ b/server/models/model.js
@@ -134,7 +134,11 @@ const queries = {
     .eq('year', year)
   ),
 
-
+  getAlbumImageUrl: (albumNameArray) => executeQuery(async (supabase) => supabase
+    .from('tracks')
+    .select('album_name, image_url')
+    .in('album_name', albumNameArray)
+  )
 
   // Old query to get Top10TracksForYear. Does not use views.
 

--- a/server/routes/albumsRouter.js
+++ b/server/routes/albumsRouter.js
@@ -7,9 +7,10 @@ router.get('/', albumsController.getTopAlbums, (req, res) => {
 });
 
 
-router.get('/ByYear', albumsController.getTopAlbumsByYear, (req, res) => {
+router.get('/ByYear', albumsController.getTopAlbumsByYear, albumsController.getAlbumsCoverArt, (req, res) => {
   return res.status(200).json(res.locals.topAlbumsByYear);
 });
+
 
 router.get('/topAlbumsByYearByMonth', albumsController.getTopAlbumsByYearByMonth, (req, res) => {
   return res.status(200).json(res.locals.topAlbumsByYearByMonth);


### PR DESCRIPTION
Minor wording changes in the middle artists component as we had discussed. 
Moved forward with the top album component. 
The top_albums_by_year view was not set up, so that query wasn't working. I used the getTopAlbumsByYearByMonth query, since that also had the data we wanted, but I had to reduce the result down to top 10 albums per year. I added a query to get image urls from tracks table, since that was the only place I could find the image urls. I append the urls to the top 10 albums results, and then I respond back to the client. 
It starts off with the default placeholder album art, but when the slider is moved, the new data is fetched which has the image urls, the component updates, and the album art is displayed.
There are cases where there is no image url, so I added a little function to send back the first album in the list with a populated image url field.